### PR TITLE
Fix Drupal ReferenceError

### DIFF
--- a/lib/libraries.js
+++ b/lib/libraries.js
@@ -25,7 +25,7 @@ const jqueryUiMatcher = (request) => {
  */
 const libraryMatcher = (request) => {
   const [, library] = /^Drupal\/(\w+\/.+)$/.exec(request) || [];
-  return library ? { library, external: `Drupal/*${library}*/` } : false;
+  return library ? { library, external: `window.Drupal/*${library}*/` } : false;
 };
 
 /**

--- a/test/libraries.test.js
+++ b/test/libraries.test.js
@@ -20,7 +20,7 @@ describe('librariesMatcher()', function () {
     const library = `${randomString()}/${randomString()}`;
     deepStrictEqual(librariesMatcher(`Drupal/${library}`), {
       library,
-      external: `Drupal/*${library}*/`,
+      external: `window.Drupal/*${library}*/`,
     });
   });
 

--- a/test/output.test.js
+++ b/test/output.test.js
@@ -130,8 +130,8 @@ return [
       'dist/other.js' => [],
     ],
     'dependencies' => [
-      'extension/library',
       'core/drupalSettings',
+      'extension/library',
       'fixtures/main',
     ],
   ],
@@ -215,8 +215,8 @@ return [
       'dist/other.js' => [],
     ],
     'dependencies' => [
-      'extension/library',
       'core/drupalSettings',
+      'extension/library',
       '${extensionName}/main',
     ],
   ],
@@ -269,8 +269,8 @@ return [
       'dist/other.js' => [],
     ],
     'dependencies' => [
-      'extension/library',
       'core/drupalSettings',
+      'extension/library',
       'fixtures/${prefix}main',
     ],
   ],


### PR DESCRIPTION
Can occur when the `core/drupal` library is not loaded but an asset
`imports` another library via `Drupal/library/name`.
